### PR TITLE
Boot Manjaro ISO from Grub2 loopback

### DIFF
--- a/cfg/grub.cfg
+++ b/cfg/grub.cfg
@@ -511,12 +511,10 @@ if [ -z "${loaded}" ]; then
     menu_color_highlight=white/blue
 
     if [ -n "${iso_path}" ]; then
-        auto="${auto} fromiso=${iso_path}"
+        auto="img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${iso_path}"
     fi
-
-    if [ -n "${auto}" ]; then
-        export auto
-    fi
+    
+    export auto
 fi
 
 boot_defaults


### PR DESCRIPTION
Refer:
https://forum.manjaro.org/t/boot-manjaro-iso-from-grub2-loopback/32985

```
menuentry "Boot Manjaro ISO from Grub2" {
	iso_path=/manjaro-xfce-17.0.5-stable-x86_64.iso
	export iso_path
	probe -u -s rootuuid $root
	export rootuuid
	loopback loop $iso_path
	root=(loop)
	configfile /boot/grub/loopback.cfg
	loopback --delete loop
}
```